### PR TITLE
🔨️ refactor : 토큰 설정 변경

### DIFF
--- a/src/main/java/potatoes/server/controller/AuthController.java
+++ b/src/main/java/potatoes/server/controller/AuthController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import potatoes.server.dto.CommonResponse;
@@ -34,8 +35,11 @@ public class AuthController {
 
 	@Operation(summary = "로그인", description = "로그인을 성공하면 SET_COOKIE형태로 토큰이 설정됩니다.")
 	@PostMapping("/sign-in")
-	public ResponseEntity<CommonResponse<?>> signIn(@RequestBody @Valid SignInRequest request) {
-		ResponseCookie tokenResponse = authService.signIn(request);
+	public ResponseEntity<CommonResponse<?>> signIn(
+		@RequestBody @Valid SignInRequest request,
+		HttpServletRequest httpRequest
+	) {
+		ResponseCookie tokenResponse = authService.signIn(request, httpRequest);
 
 		return ResponseEntity.ok()
 			.header(HttpHeaders.SET_COOKIE, tokenResponse.toString())

--- a/src/main/java/potatoes/server/service/AuthService.java
+++ b/src/main/java/potatoes/server/service/AuthService.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import potatoes.server.dto.SignInRequest;
 import potatoes.server.dto.SignUpRequest;
@@ -26,7 +27,7 @@ public class AuthService {
 	private final CookieProvider cookieProvider;
 	private final JwtTokenUtil jwtTokenUtil;
 
-	public ResponseCookie signIn(SignInRequest request) {
+	public ResponseCookie signIn(SignInRequest request, HttpServletRequest httpRequest) {
 		User getUser = userRepository.findByEmail(request.email())
 			.orElseThrow(() -> new WeGoException(INVALID_CREDENTIALS));
 
@@ -36,7 +37,7 @@ public class AuthService {
 		}
 
 		String accessToken = jwtTokenUtil.createAccessToken(getUser.getId().toString());
-		return cookieProvider.accessTokenCookie(accessToken);
+		return cookieProvider.accessTokenCookie(accessToken, httpRequest);
 	}
 
 	@Transactional

--- a/src/main/java/potatoes/server/utils/crypto/CookieProvider.java
+++ b/src/main/java/potatoes/server/utils/crypto/CookieProvider.java
@@ -28,7 +28,7 @@ public class CookieProvider {
 			.sameSite("None");
 
 		if (!isLocalhost) {
-			cookieBuilder.domain("we-go.world");
+			cookieBuilder.domain(domain);
 		}
 
 		return cookieBuilder.build();


### PR DESCRIPTION
쿠키 samesite 해제에 따른 크롬 요구사항으로 secure을 true로 변경
&
프론트 요청주소가 다름에 따른 쿠키 domain을 설정 분기

<!--
체크하려면 괄호 안에 "x"를 입력하세요.
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.

✨ feat : 새로운 기능
🔨️ refactor : 코드 리팩토링
🐎 perf : 성능을 향상
🐛 fix : 버그를 고칠 때
🧪 test : 테스트 코드
🚜 rename : 파일 이름 변경 혹은 구조를 변경
🚀 deployment : 배포 / 개발 작업과 관련된 모든 것
🔥 remove : 코드 또는 파일 제거
📚 docs : 문서
📝 chore : 사소한 코드 또는 언어를 변경 기타 변경사항 (빌드 스크립트 수정, 패키지 매니징 설정 등)

-->

## PR 타입

<!-- 어떤 유형의 PR인지 체크해주세요. -->

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Performance Improvement
- [ ] Bugfix
- [ ] Test Code
- [ ] Code style update (formatting, local variables)
- [ ] Other... Please describe:

## 개요

- 쿠키 설정 변경

## 작업 및 변경 사항

- samesite 설정을 false로 변경을 하여 써드파티 쿠키로 만들게 되면 크롬 요구사항으로 secure 설정이 무조건 true 여야함
- 프론트 요청주소가 달라서(localhost, 도메인) domain설정이 없을시 운영환경에서 토큰이 안넘어감

close #78 
